### PR TITLE
Explicitly initialize UserConfig values to avoid undefined dereference.

### DIFF
--- a/rest.rb
+++ b/rest.rb
@@ -2,6 +2,10 @@
 # Rest API で定期的にタイムラインを更新するプラグイン
 
 Plugin.create :rest do
+  UserConfig[:retrieve_interval_friendtl] ||= 1
+  UserConfig[:retrieve_interval_mention]  ||= 20
+  UserConfig[:retrieve_count_friendtl]    ||= 20
+  UserConfig[:retrieve_count_mention]     ||= 20
 
   def self.define_periodical_executer(api, interval, count, &success)
     counter = UserConfig[interval]


### PR DESCRIPTION
https://github.com/mikutter/rest/issues/1
で挙がった UserConfig の interval 値の初期値追加です